### PR TITLE
MNT: Rename project.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
   - pytest example/
   - make -C docs html
   - pip install doctr
-  - doctr deploy --key-path github_deploy_key_nsls_ii_nsls_ii_github_io.enc --built-docs docs/build/html/ --deploy-repo NSLS-II/NSLS-II.github.io packaging-scientific-python
+  - doctr deploy --key-path github_deploy_key_nsls_ii_nsls_ii_github_io.enc --built-docs docs/build/html/ --deploy-repo NSLS-II/NSLS-II.github.io scientific-python-cookiecutter

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Packaging Scientific Python
+# Scientific Python Cookiecutter
 
-**[Documentation](https://nsls-ii.github.io/packaging-scientific-python/)**
+**[Documentation](https://nsls-ii.github.io/scientific-python-cookiecutter/)**
 
 This repository contains a cookiecutter template for generating a scientific
 Python project complete with CI testing and documentation.
 
 ```
-cookiecutter https://github.com/NSLS-II/packaging-scientific-python
+cookiecutter https://github.com/NSLS-II/scientific-python-cookiecutter
 ```
 
 Separately, beside the cookiecutter template, it contains
-[tutorial documentation](https://nsls-ii.github.io/packaging-scientific-python/)
-on how to use this template to organize scientific Python code into a package.
+[tutorial documentation](https://nsls-ii.github.io/scientific-python-cookiecutter/)
+on how to use this template to organize scientific Python code into a package
+and use popular tools for testing, documentation, and maintenance.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Packaging Scientific Python documentation build configuration file, created by
+# Scientific Python Cookiecutter documentation build configuration file, created by
 # sphinx-quickstart on Thu Jun 28 12:35:56 2018.
 #
 # This file is execfile()d with the current directory set to its
@@ -67,7 +67,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Packaging Scientific Python'
+project = 'Scientific Python Cookiecutter'
 copyright = '2018, Contributors'
 author = 'Contributors'
 
@@ -135,7 +135,7 @@ html_sidebars = {
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'PackagingScientificPythondoc'
+htmlhelp_basename = 'ScientificPythonCookiecutterdoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -162,7 +162,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'PackagingScientificPython.tex', 'Packaging Scientific Python Documentation',
+    (master_doc, 'ScientificPythonCookiecutter.tex', 'Scientific Python Cookiecutter Documentation',
      'Contributors', 'manual'),
 ]
 
@@ -172,7 +172,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'packagingscientificpython', 'Packaging Scientific Python Documentation',
+    (master_doc, 'scientificpythoncookiecutter', 'Scientific Python Cookiecutter Documentation',
      [author], 1)
 ]
 
@@ -183,8 +183,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'PackagingScientificPython', 'Packaging Scientific Python Documentation',
-     author, 'PackagingScientificPython', 'One line description of project.',
+    (master_doc, 'ScientificPythonCookiecutter', 'Scientific Python Cookiecutter Documentation',
+     author, 'ScientificPythonCookiecutter', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,11 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Packaging Scientific Python
-===========================
+Bootstrap a Scientific Python Library
+=====================================
 
-This is a tutorial with a template for packaging, documenting, and testing
-scientific Python code.
+This is a tutorial with a template for packaging, testing, documenting, and
+publishing scientific Python code.
 
 Do you have a folder of disorganized scientific Python scripts? Are you always
 hunting for code snippets scattered across dozens of Jupyter notebooks? Has it

--- a/docs/source/preliminaries.rst
+++ b/docs/source/preliminaries.rst
@@ -52,7 +52,7 @@ template.
 
    .. code-block:: bash
 
-      cookiecutter https://github.com/NSLS-II/packaging-scientific-python
+      cookiecutter https://github.com/NSLS-II/scientific-python-cookiecutter
       full_name [Name or Organization]: Brookhaven National Lab
       email []: dallan@bnl.gov
       github_username []: danielballan


### PR DESCRIPTION
I originally called this "packaging scientific Python," employing a loose usage
of the word "packaging" that I now think is too confusing. Let's reserve
"packaging" for its technical meaning.