### PR TITLE
FIX: Add pytest to outer requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ matplotlib
 numpy
 numpydoc
 pexpect
+pytest
 sphinx
 sphinx-copybutton
 sphinx_rtd_theme


### PR DESCRIPTION
Surprisingly, the tests run on Travis-CI without this. I suppose that
Travis must include pytest in its testing venv by default.