### PR TITLE
ENH: fix version error in setup.py

### DIFF
--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -7,10 +7,11 @@ import versioneer
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-if sys.version_info < ({{ cookiecutter.minimum_supported_python_version [0] }}, {{ cookiecutter.minimum_supported_python_version [2] }}):
+min_version = (cookiecutter.minimum_supported_python_version [0], cookiecutter.minimum_supported_python_version [2])
+if sys.version_info < min_version:
     error = """
-{{ cookiecutter.package_dist_name }} does not support Python {0}.{2}.
-Python {{ cookiecutter.minimum_supported_python_version }} and above is required. Check your Python version like so:
+{{ cookiecutter.package_dist_name }} does not support Python {0}.{1}.
+Python {2}.{3} and above is required. Check your Python version like so:
 
 python3 --version
 
@@ -18,7 +19,7 @@ This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
 Upgrade pip like so:
 
 pip install --upgrade pip
-""".format({{ cookiecutter.minimum_supported_python_version [0] }}, {{ cookiecutter.minimum_supported_python_version [2] }})
+""".format(*sys.version_info[:2], *min_version)
     sys.exit(error)
 
 here = path.abspath(path.dirname(__file__))

--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -7,7 +7,7 @@ import versioneer
 # NOTE: This file must remain Python 2 compatible for the foreseeable future,
 # to ensure that we error out properly for people with outdated setuptools
 # and/or pip.
-min_version = (cookiecutter.minimum_supported_python_version [0], cookiecutter.minimum_supported_python_version [2])
+min_version = ({{ cookiecutter.minimum_supported_python_version [0] }}, {{ cookiecutter.minimum_supported_python_version [2] }})
 if sys.version_info < min_version:
     error = """
 {{ cookiecutter.package_dist_name }} does not support Python {0}.{1}.


### PR DESCRIPTION
I noticed that this was generated in [setup.py](https://github.com/mrakitin/srwpy/blob/3bd395ff4c1bf07f1c7e08318896452654da10e5/setup.py#L10-L22):
```py
if sys.version_info < (3, 6):
    error = """
srwpy does not support Python {0}.{2}.
Python 3.6 and above is required. Check your Python version like so:

python3 --version

This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
Upgrade pip like so:

pip install --upgrade pip
""".format(3, 6)
```
However, we don't have the third argument to unpack (for `.{2}`), hence the PR.