### PR TITLE
ENH: (still) support Python 2.7

### DIFF
--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -13,13 +13,13 @@ if sys.version_info < min_version:
 {{ cookiecutter.package_dist_name }} does not support Python {0}.{1}.
 Python {2}.{3} and above is required. Check your Python version like so:
 
-python3 --version
+python --version
 
 This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
 Upgrade pip like so:
 
 pip install --upgrade pip
-""".format(*sys.version_info[:2], *min_version)
+""".format(*(list(sys.version_info[:2]) + list(min_version)))
     sys.exit(error)
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
An issue with installing on Python 2.7 was observed while working on the CI for https://github.com/srwpy/srwpy, which is based on this cookiecutter template.

### Demo:
```py
Python 2.7.15 |Anaconda, Inc.| (default, Oct 23 2018, 13:35:16)
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> print('{0}{1}{2}{3}'.format(*[1, 2], *[3, 4]))
  File "<stdin>", line 1
    print('{0}{1}{2}{3}'.format(*[1, 2], *[3, 4]))
                                         ^
SyntaxError: invalid syntax
>>> print('{0}{1}{2}{3}'.format(*([1, 2] + [3, 4])))
1234
>>>
```