### PR TITLE
modifying the example to use radians instead of degrees

### DIFF
--- a/docs/source/refraction.py
+++ b/docs/source/refraction.py
@@ -23,9 +23,10 @@ def snell(theta_inc, n1, n2):
 
     Examples
     --------
-    A ray enters an air--water boundary at 45 degrees. Compute exit angle.
+    A ray enters an air--water boundary at pi/4 radians (45 degrees).
+    Compute exit angle.
 
-    >>> snell(np.deg2rad(45), 1.00, 1.33)
+    >>> snell(np.pi/4, 1.00, 1.33)
     0.5605584137424605
     """
     return np.arcsin(n1 / n2 * np.sin(theta_inc))

--- a/docs/source/test_examples.py
+++ b/docs/source/test_examples.py
@@ -21,6 +21,6 @@ def test_perpendicular():
 
 def test_air_water():
     n_air, n_water = 1.00, 1.33
-    actual = snell(np.deg2rad(45), n_air, n_water)
+    actual = snell(np.pi/4, n_air, n_water)
     expected = 0.5605584137424605
     assert np.allclose(actual, expected)

--- a/docs/source/the-code-itself.rst
+++ b/docs/source/the-code-itself.rst
@@ -132,7 +132,7 @@ Try importing and using the function.
 
     >>> from example.refraction import snell
     >>> import numpy as np
-    >>> snell(np.deg2rad(45), 1.00, 1.33))
+    >>> snell(np.pi/4, 1.00, 1.33))
     1.2239576240104186
 
 The docstring can be viewed with :func:`help`.

--- a/docs/source/writing-docs.rst
+++ b/docs/source/writing-docs.rst
@@ -186,15 +186,13 @@ documentation is built. This rst code:
 
    .. ipython:: python
 
-      import numpy as np
-      np.deg2rad(90)
+      1 + 1
 
 renders in HTML as:
 
 .. ipython:: python
 
-   import numpy as np
-   np.deg2rad(90)
+    1 + 1
 
 From here we refer you to the
 `IPython sphinx directive documentation <https://ipython.org/ipython-doc/rel-0.13.2/development/ipython_directive.html>`_.


### PR DESCRIPTION
It was requested by a user that we could simplify the example by using radians instead of degrees, and removing the np.deg2rad(...) calls.

This PR addresses that issue