### PR TITLE
Add codecov configuration.

### DIFF
--- a/{{ cookiecutter.repo_name }}/.codecov.yml
+++ b/{{ cookiecutter.repo_name }}/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment. 
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto


### PR DESCRIPTION
THis configuration file lets codecov weigh in on the "checks"
shown by GitHub but suppresses the giant comment generated by its bot.

We have added to several of our projects and appreciate it.