### PR TITLE
Add .coveragerc.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,6 @@
     "project_name": "Your Project Name",
     "package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
     "package_dir_name": "{{ cookiecutter.project_name|replace(' ', '_')|lower }}",
-    "package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
     "repo_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
     "project_short_description": "Python package for doing science.",
     "year": "2019",

--- a/{{ cookiecutter.repo_name }}/.coveragerc
+++ b/{{ cookiecutter.repo_name }}/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source =
+    {{ cookiecutter.package_dir_name }}
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*
+    # ignore _version.py and versioneer.py
+    .*version.*
+    *_version.py
+
+exclude_lines =
+    if __name__ == '__main__':


### PR DESCRIPTION
This makes the coverage report much more readable and succinct by only measuring coverage of the package whose CI is being run, not every installed package.

This PR also fixes a typo in ``cookiecutter.json``.