### PR TITLE
Typo in ci.html

### DIFF
--- a/docs/source/ci.rst
+++ b/docs/source/ci.rst
@@ -59,5 +59,5 @@ Activate Travis-CI for Your GitHub Repository
     above for the organization's profile at
     ``https://travis-ci.org/profile/YOUR_GITHUB_ORGANIZATION``. It does no
     harm to *also* activate Travis-CI for your personal fork at
-    ``https://travis.org/profile``, but it's more important to activate it for
+    ``https://travis-ci.org/profile``, but it's more important to activate it for
     the upstream fork associated with the organization.


### PR DESCRIPTION
There is a typo on the page https://nsls-ii.github.io/scientific-python-cookiecutter/ci.html. There is a note at the very end of the page. The link says travis.org which is a Baptist Church instead of travis-ci.org. I have created a pull request that will change the typo.

```
.. note::
    If this repository belongs to a GitHub *organization* (e.g.
    http://github.com/NSLS-II) as opposed to a personal user account
    (e.g. http://github.com/danielballan) you should follow Steps 3-5
    above for the organization's profile at
    ``https://travis-ci.org/profile/YOUR_GITHUB_ORGANIZATION``. It does no
    harm to *also* activate Travis-CI for your personal fork at
    **``https://travis.org/profile``**, but it's more important to activate it for
    the upstream fork associated with the organization
```