### PR TITLE
Match section separator's and project name's lengths

### DIFF
--- a/{{ cookiecutter.repo_name }}/README.rst
+++ b/{{ cookiecutter.repo_name }}/README.rst
@@ -1,6 +1,7 @@
-===============================
+{% set section_separator = "=" * cookiecutter.project_name | length -%}
+{{ section_separator }}
 {{ cookiecutter.project_name }}
-===============================
+{{ section_separator }}
 
 .. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}.svg
         :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}


### PR DESCRIPTION
# Summary

This PR provides a fix for the long project names to be properly rendered in the generated `README.rst` files.

# Demo
```bash
19:18 $ cookiecutter .
full_name [Name or Organization]:
email []:
github_username []:
project_name [Your Project Name]: very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77
package_dist_name [very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77]:
package_dir_name [very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77]:
repo_name [very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77]:
project_short_description [Python package for doing science.]:
year [2019]:
Select minimum_supported_python_version:
1 - 3.6
2 - 3.7
3 - 3.5
4 - 3.4
Choose from 1, 2, 3, 4 (1, 2, 3, 4) [1]:
19:18 $ cat very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77/README.rst
============================================================================
very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77
============================================================================

.. image:: https://img.shields.io/travis//very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77.svg
        :target: https://travis-ci.org//very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77

.. image:: https://img.shields.io/pypi/v/very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77.svg
        :target: https://pypi.python.org/pypi/very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77


Python package for doing science.

* Free software: 3-clause BSD license
* Documentation: (COMING SOON!) https://.github.io/very-very-long-name-we-all-would-like-to-handle-properly-see-issue-number-77.

Features
--------

* TODO
```

# Refs
Closes #77.