### PR TITLE
DOC: update doctr instruction

### DIFF
--- a/docs/source/publishing-docs.rst
+++ b/docs/source/publishing-docs.rst
@@ -15,6 +15,9 @@ We recommend `doctr <https://drdoctr.github.io/doctr/>`_ a tool that configures
 Travis-CI to automatically publish your documentation every time the master
 branch is updated.
 
+**WANRING: The repo you want to build the docs for has to be a root repo. You
+cannot build docs for a forked repo by doctr.**
+
 Install doctr.
 
    .. code-block:: bash

--- a/docs/source/publishing-docs.rst
+++ b/docs/source/publishing-docs.rst
@@ -18,7 +18,8 @@ branch is updated.
 .. warning::
     The repo you want to build the docs for has to be a root repo.
     You cannot build docs for a forked repo by doctr.
-    doctr is working on enable forked repo build under `PR343 <https://github.com/drdoctr/doctr/pull/343>`_
+    The doctr team is working on enabling a forked repo build under
+    `PR #343 <https://github.com/drdoctr/doctr/pull/343>`_.
 
 Install doctr.
 

--- a/docs/source/publishing-docs.rst
+++ b/docs/source/publishing-docs.rst
@@ -15,8 +15,10 @@ We recommend `doctr <https://drdoctr.github.io/doctr/>`_ a tool that configures
 Travis-CI to automatically publish your documentation every time the master
 branch is updated.
 
-**WARNING: The repo you want to build the docs for has to be a root repo. You
-cannot build docs for a forked repo by doctr.**
+.. warning::
+    The repo you want to build the docs for has to be a root repo.
+    You cannot build docs for a forked repo by doctr.
+    doctr is working on enable forked repo build under `PR343 <https://github.com/drdoctr/doctr/pull/343>`_
 
 Install doctr.
 

--- a/docs/source/publishing-docs.rst
+++ b/docs/source/publishing-docs.rst
@@ -15,7 +15,7 @@ We recommend `doctr <https://drdoctr.github.io/doctr/>`_ a tool that configures
 Travis-CI to automatically publish your documentation every time the master
 branch is updated.
 
-**WANRING: The repo you want to build the docs for has to be a root repo. You
+**WARNING: The repo you want to build the docs for has to be a root repo. You
 cannot build docs for a forked repo by doctr.**
 
 Install doctr.

--- a/docs/source/publishing-docs.rst
+++ b/docs/source/publishing-docs.rst
@@ -17,7 +17,7 @@ branch is updated.
 
 .. warning::
     The repo you want to build the docs for has to be a root repo.
-    You cannot build docs for a forked repo by doctr.
+    You cannot build docs for a forked repo by doctr yet.
     The doctr team is working on enabling a forked repo build under
     `PR #343 <https://github.com/drdoctr/doctr/pull/343>`_.
 


### PR DESCRIPTION
Reason: https://github.com/drdoctr/doctr/blob/0f19ff78c8239efcc98d417f36b0a31d9be01ba5/doctr/travis.py#L593

It's very hard to find in Travis log. Think need to mention in instruction.