### PR TITLE
Update docs and development requirements

### DIFF
--- a/docs/source/guiding-design-principles.rst
+++ b/docs/source/guiding-design-principles.rst
@@ -165,7 +165,7 @@ function, shortening this:
 
 .. code-block:: python
 
-    get_image(filename, normalize=True, beginning=0, end=None):
+    def get_image(filename, normalize=True, beginning=0, end=None):
         ...
 
 into this:

--- a/{{ cookiecutter.repo_name }}/requirements-dev.txt
+++ b/{{ cookiecutter.repo_name }}/requirements-dev.txt
@@ -5,6 +5,7 @@ coverage
 flake8
 pytest
 sphinx
+twine
 # These are dependencies of various sphinx extensions for documentation.
 ipython
 matplotlib


### PR DESCRIPTION
`twine` is pretty useful when installed with the rest of the development requirements.