### PR TITLE
Fix remaining inconsistencies in templated LICENSE file

### DIFF
--- a/{{ cookiecutter.repo_name }}/LICENSE
+++ b/{{ cookiecutter.repo_name }}/LICENSE
@@ -1,19 +1,21 @@
+BSD 3-Clause License
+
 Copyright (c) {{ cookiecutter.year }}, {{ cookiecutter.full_name }}
-Laboratory. All rights reserved.
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the Brookhaven Science Associates, Brookhaven National
-  Laboratory nor the names of its contributors may be used to endorse or promote
-  products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE


### PR DESCRIPTION
Closes #42. 

Follow-up on #46.

The templated LICENSE file, which is then shipped with projects generated using the cookiecutter, still has a couple of references to BNL/BSA. Other details and formatting are also not quite consistent with the standard BSD 3-Clause license.

This PR removes all remaining BNL references, and brings the file in line with the "standard" as per:

https://choosealicense.com/licenses/bsd-3-clause/

The resulting LICENSE is recognized by GitHub as a standard BSD 3-Clause license.