### PR TITLE
Upgrade pip and numpy from Travis defaults.

### DIFF
--- a/{{ cookiecutter.repo_name }}/.travis.yml
+++ b/{{ cookiecutter.repo_name }}/.travis.yml
@@ -7,6 +7,9 @@ cache:
     - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
 
 install:
+  # The versions of pip and numpy that come pre-installed are often too old and
+  # can cause problems. Upgrade them.
+  - pip install --upgrade pip numpy
   # Install this package and the packages listed in requirements.txt.
   - pip install .
   # Install extra requirements for running tests and building docs.


### PR DESCRIPTION
This seems to help avoid many potentially-confusing issues, most recently
the one with imagecodecs.