### PR TITLE
Pypitoken

### DIFF
--- a/docs/source/publishing-releases.rst
+++ b/docs/source/publishing-releases.rst
@@ -136,7 +136,8 @@ wait to publish a release until your package is usable and tested.
 
       git clean -dfx
 
-#. Publish a release on PyPI.
+#. Publish a release on PyPI. Note that you might need to configure
+   your ``~/.pypirc`` with a login token.
 
    .. code-block:: bash
 

--- a/docs/source/publishing-releases.rst
+++ b/docs/source/publishing-releases.rst
@@ -137,7 +137,7 @@ wait to publish a release until your package is usable and tested.
       git clean -dfx
 
 #. Publish a release on PyPI. Note that you might need to configure
-   your `~/.pypirc` with a login token.
+   your ``~/.pypirc`` with a login token. See `the packaging documentation <https://packaging.python.org/specifications/pypirc/>_` for more details.
 
    .. code-block:: bash
 

--- a/docs/source/publishing-releases.rst
+++ b/docs/source/publishing-releases.rst
@@ -137,7 +137,7 @@ wait to publish a release until your package is usable and tested.
       git clean -dfx
 
 #. Publish a release on PyPI. Note that you might need to configure
-   your ``~/.pypirc`` with a login token.
+   your `~/.pypirc` with a login token.
 
    .. code-block:: bash
 


### PR DESCRIPTION
This adds a note about `~/.pypirc`, which confused me a bit when trying to follow the instructions. 