### PR TITLE
Add reminder to restore editable installation after git cleaning.

### DIFF
--- a/docs/source/publishing-releases.rst
+++ b/docs/source/publishing-releases.rst
@@ -152,3 +152,12 @@ If you would also like to make your package available via conda, we recommend
 conda-forge, a community-led collection of recipes and build infrastructure.
 See in particular
 `the section of the conda-forge documentation on adding a recipe <https://conda-forge.org/#add_recipe>`_.
+
+#. Finally, if you generally work with an "editable" installation of the
+   package on your machine, as we suggested in :doc:`preliminaries`, you'll
+   need to reinstall because running ``git clean -dfx`` above will have wiped
+   out your installation.
+
+   .. code-block:: bash
+
+      pip install -e .


### PR DESCRIPTION
This is a step I sometimes forget at first. Seems worth adding to the instructions.