### PR TITLE
relax pre-commit python version specification 

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -1,9 +1,10 @@
+default_language_version:
+    python: python3
 repos:
   - repo: https://github.com/ambv/black
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:


### PR DESCRIPTION
I got in a fight with pre-commit because it wanted python 3.7 and I was using python 3.8. This PR relaxes the python version specification.