### PR TITLE
Black: set maximum line length to 115 characters

### DIFF
--- a/{{ cookiecutter.repo_name }}/.flake8
+++ b/{{ cookiecutter.repo_name }}/.flake8
@@ -8,3 +8,4 @@ exclude =
     {{ cookiecutter.package_dir_name }}/_version.py,
     docs/source/conf.py
 max-line-length = 115
+ignore = E203, W503  # Ignore some style 'errors' produced while formatting by 'black'

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -18,4 +18,3 @@ exclude = '''
   | tests/data
 )/
 '''
-

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.black]
+line-length = 115
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -17,3 +18,4 @@ exclude = '''
   | tests/data
 )/
 '''
+


### PR DESCRIPTION
Configuration for `black` tool: set maximum line length to 115 characters (same line length is used in `flake8` configuration). The default line length 88 characters is not practical for most cases. The line length can be manually reduced for particular projects is needed, since it is much easier to reformat the code to make lines shorter than fix the code that was accidentally formatted with short lines (there is no automated way to reverse changes).

Configuration for `flake8` was changed to ignore some style issues produced by `black`. Those issues are unavoidable in the formatted code and should be ignored by `flake8` if it is used along with `black`. For example, `flake8` requires that the slices are specified as `[2: 5]` (no space before `:`), while `black` formats slices as `[2 : 5]` (which looks better, but causes validation errors with `flake8` (error code E203).  The description of another issue (error code W503) can be found here: https://www.flake8rules.com/rules/W503.html