### PR TITLE
Defaulting documentation to compile with English as language

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,7 @@ release = '0.1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -86,7 +86,7 @@ release = {{ cookiecutter.package_dir_name }}.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
This is the default behavior of Sphinx anyways, but it raises a warning to let the user know that it is subbing in `en` for `None` in the language field. These warnings cause GH Actions to fail, as seen here:
https://github.com/NSLS-II/scientific-python-cookiecutter/runs/6996988582?check_suite_focus=true