### PR TITLE
Make .flake8 compatible with flake8 v6.0.0

### DIFF
--- a/{{ cookiecutter.repo_name }}/.flake8
+++ b/{{ cookiecutter.repo_name }}/.flake8
@@ -8,4 +8,5 @@ exclude =
     {{ cookiecutter.package_dir_name }}/_version.py,
     docs/source/conf.py
 max-line-length = 115
-ignore = E203, W503  # Ignore some style 'errors' produced while formatting by 'black'
+# Ignore some style 'errors' produced while formatting by 'black'
+ignore = E203, W503


### PR DESCRIPTION
Putting a comment (starting with #) in the line with the list of `ignore` errors causes `flake8` v6.0.0 to crash. Move the comment to a separate line.