### PR TITLE
ENH: some additions to CI from event-model

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
             # Test the style with pre-commit
             cd example/
             git config --global user.name "CI Tester"
+            git config --global user.email "noreply@github.com"
             git init
             git add .
             git commit -m "Initial commit"

--- a/{{ cookiecutter.repo_name }}/.github/workflows/docs.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/docs.yml
@@ -3,9 +3,13 @@ name: Build Documentation
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build_docs:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/{{ cookiecutter.repo_name }}/.github/workflows/pre-commit.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/pre-commit.yml
@@ -3,9 +3,13 @@ name: pre-commit
 on:
   pull_request:
   push:
+  workflow_dispatch:
 
 jobs:
   pre-commit:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/{{ cookiecutter.repo_name }}/.github/workflows/testing.yml
+++ b/{{ cookiecutter.repo_name }}/.github/workflows/testing.yml
@@ -3,11 +3,15 @@ name: Unit Tests
 on:
   push:
   pull_request:
+  workflow_dispatch:
   # schedule:
   #   - cron: '00 4 * * *'  # daily at 4AM
 
 jobs:
   run_tests:
+    # pull requests are a duplicate of a branch push if within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+
     runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/ambv/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
After using the new templates brought by #105, we figured out there can be a few nice additions currently in use in another project, [event-model](https://github.com/bluesky/event-model) (implemented via a separate skeleton approach).

Here I add a couple of useful configuration items:
- run only one workflow job in case of a PR is opened from the same repo;
- add an option to manually trigger a workflow (via [`workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)).